### PR TITLE
Add Windows packaging script

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,3 +135,11 @@ python gui.py
 - **main** – 命令行模式入口。
 - **settings** – 配置文件及生成脚本的路径设置。
 
+
+### Packaging for Windows
+
+You can create a standalone Windows executable using `PyInstaller`. A helper script `package_app.bat` is provided:
+```cmd
+package_app.bat
+```
+The generated executable will appear in the `dist` folder.

--- a/package_app.bat
+++ b/package_app.bat
@@ -1,0 +1,19 @@
+@echo off
+rem Package the MCAA-Phase1 application using PyInstaller
+
+rem Install PyInstaller if it's not already available
+pyinstaller --version >nul 2>&1
+if errorlevel 1 (
+    echo Installing PyInstaller...
+    pip install pyinstaller
+)
+
+rem Create a standalone executable
+pyinstaller --onefile --name mcaa_app main.py
+
+rem Inform the user of the output location
+if exist dist\mcaa_app.exe (
+    echo Package created successfully: dist\mcaa_app.exe
+) else (
+    echo Packaging failed. See output above for details.
+)


### PR DESCRIPTION
## Summary
- add `package_app.bat` for building a Windows executable using PyInstaller
- document packaging instructions in the README

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pyinstaller --onefile main.py` *(fails: command not found)*
- `pip install pyinstaller` *(fails due to network restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_6860758e17748325b45197c31f9ac11c